### PR TITLE
Upgrade deprecated runtime nodejs14.x

### DIFF
--- a/amplify/backend/function/AddDevice/AddDevice-cloudformation-template.json
+++ b/amplify/backend/function/AddDevice/AddDevice-cloudformation-template.json
@@ -90,7 +90,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/AddUser/AddUser-cloudformation-template.json
+++ b/amplify/backend/function/AddUser/AddUser-cloudformation-template.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/Authorizer/Authorizer-cloudformation-template.json
+++ b/amplify/backend/function/Authorizer/Authorizer-cloudformation-template.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/CreateWork/CreateWork-cloudformation-template.json
+++ b/amplify/backend/function/CreateWork/CreateWork-cloudformation-template.json
@@ -96,7 +96,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/DeviceUploadTrigger/DeviceUploadTrigger-cloudformation-template.json
+++ b/amplify/backend/function/DeviceUploadTrigger/DeviceUploadTrigger-cloudformation-template.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/GetDevice/GetDevice-cloudformation-template.json
+++ b/amplify/backend/function/GetDevice/GetDevice-cloudformation-template.json
@@ -87,7 +87,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/GetDeviceWork/GetDeviceWork-cloudformation-template.json
+++ b/amplify/backend/function/GetDeviceWork/GetDeviceWork-cloudformation-template.json
@@ -87,7 +87,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/GetWork/GetWork-cloudformation-template.json
+++ b/amplify/backend/function/GetWork/GetWork-cloudformation-template.json
@@ -87,7 +87,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/ListDevices/ListDevices-cloudformation-template.json
+++ b/amplify/backend/function/ListDevices/ListDevices-cloudformation-template.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/ListWork/ListWork-cloudformation-template.json
+++ b/amplify/backend/function/ListWork/ListWork-cloudformation-template.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/PutDeviceWork/PutDeviceWork-cloudformation-template.json
+++ b/amplify/backend/function/PutDeviceWork/PutDeviceWork-cloudformation-template.json
@@ -87,7 +87,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/UpdateDevice/UpdateDevice-cloudformation-template.json
+++ b/amplify/backend/function/UpdateDevice/UpdateDevice-cloudformation-template.json
@@ -90,7 +90,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }

--- a/amplify/backend/function/UploadTrigger/UploadTrigger-cloudformation-template.json
+++ b/amplify/backend/function/UploadTrigger/UploadTrigger-cloudformation-template.json
@@ -84,7 +84,7 @@
             "Arn"
           ]
         },
-        "Runtime": "nodejs14.x",
+        "Runtime": "nodejs16.x",
         "Layers": [],
         "Timeout": 25
       }


### PR DESCRIPTION
CloudFormation templates in cloud-queue-for-quantum-devices have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs14.x). The affected templates have been updated to a supported runtime (nodejs16.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.